### PR TITLE
Fix open new tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,4 @@ version|description
 3.1.0| #339
 3.1.1| Security Updates
 3.1.2| #446
-
+3.2.3| #447

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "r-confluence-pagetree-search",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "main": "index.js",
   "license": "MIT",
   "scripts": {

--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -117,7 +117,7 @@ export default class App extends Vue {
     if (e.isComposing) {
       return
     }
-    if (e.metaKey) {
+    if (e.metaKey || e.ctrlKey) {
       window.open(completions.nodeList[completions.selectIndex].url, '_blank')
     } else {
       location.href = completions.nodeList[completions.selectIndex].url

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "R-Confluence Pagetree Search",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Add a feature to search page tree by its name.",
   "content_security_policy": {
     "extension_pages": "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self';base-uri 'self';form-action 'self'"


### PR DESCRIPTION
To get if <kbd>ctrl</kbd> is pressed, use [ctrlKey](https://developer.mozilla.org/ja/docs/Web/API/KeyboardEvent/ctrlKey) instead of [metaKey](https://developer.mozilla.org/ja/docs/Web/API/KeyboardEvent/metaKey)